### PR TITLE
Enhance docs for custody api

### DIFF
--- a/src/trading-api/current/bullish-trading-api.yml
+++ b/src/trading-api/current/bullish-trading-api.yml
@@ -1822,7 +1822,7 @@ tags:
     description: |+
       Authenticated APIs for custody,  [Custody Basic Examples](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_basics.py)
       
-      Custody APIs have a limit of 40 requests per minute combined across all endpoints of type **/wallets/***
+      Custody APIs have a limit of 40 requests per IP, per minute. This is combined across all endpoints of type **/wallets/***
   - name: trades
     description: Authenticated APIs for reading trade data
   - name: accounts
@@ -3791,7 +3791,7 @@ paths:
         - custody
       summary: Get Custody Transaction History
       description: |
-        Get custody transaction history requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get custody transaction history, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         - [supports pagination](#overview--pagination-support)
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
@@ -3826,7 +3826,7 @@ paths:
         - custody
       summary: Get Withdrawal Limits for Symbol
       description: |
-        Get withdrawal limits for symbol [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal limits for symbol, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-limits
@@ -3861,7 +3861,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Crypto
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions requires, [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -3898,7 +3898,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Crypto
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -3935,7 +3935,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Fiat
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -3973,7 +3973,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Fiat
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. 
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -4010,13 +4010,13 @@ paths:
         - custody
       summary: Create Withdrawal Challenge
       description: |
-        Request a withdrawal challenge for signing, this can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Request a withdrawal challenge for signing which can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         > **Bullish requires you to whitelist a withdrawal destination address before submitting a withdrawal request. You may view, approve, and manage your list of destination addresses in Account Settings on the Bullish website. If you attempt a withdrawal without first whitelisting an address in Account Settings, then the withdrawal attempt will fail.**
         
-        For a full example of using the withdrawal endpoints please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_withdrawals.py)
+        For a full example of using the withdrawal endpoints, please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_withdrawals.py)
         
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
         
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -4072,7 +4072,7 @@ paths:
         - custody
       summary: Assertion for Withdrawal Challenge
       description: |
-        Make assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Make an assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-withdrawal-assertion
@@ -4126,7 +4126,7 @@ paths:
 
         For a full example of using the withdrawal endpoint please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/ecdsa/rest/custody_withdrawal.py)
 
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
 
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -4998,11 +4998,11 @@ components:
     CustodyAvailableWithdrawalLimit:
       type: string
       example: "20000.0"
-      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     Custody24HWithdrawalLimit:
       type: string
       example: "1000000.00"
-      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     CustodyCreatedAtDateTime:
       type: string
       example: "2022-09-16T07:56:15.000Z"

--- a/src/trading-api/draft/custody-vanilla-ecdsa/bullish-trading-api.yml
+++ b/src/trading-api/draft/custody-vanilla-ecdsa/bullish-trading-api.yml
@@ -1337,7 +1337,7 @@ tags:
     description: |+
       Authenticated APIs for custody,  [Custody Basic Examples](https://github.com/bullish-exchange/api-examples/blob/master/custody_basics.py)
       
-      Custody APIs have a limit of 40 requests per minute combined across all endpoints of type **/wallets/***
+      Custody APIs have a limit of 40 requests per IP, per minute. This is combined across all endpoints of type **/wallets/***
   - name: trades
     description: Authenticated APIs for reading trade data
   - name: accounts
@@ -2727,7 +2727,7 @@ paths:
         - custody
       summary: Get Custody Transaction History
       description: |
-        Get custody transaction history requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get custody transaction history, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         - [supports pagination](#overview--pagination-support)
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
@@ -2762,7 +2762,7 @@ paths:
         - custody
       summary: Get Withdrawal Limits for Symbol
       description: |
-        Get withdrawal limits for symbol [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal limits for symbol, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-limits
@@ -2797,7 +2797,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Crypto
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions requires, [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -2834,7 +2834,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Crypto
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -2871,7 +2871,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Fiat
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -2909,7 +2909,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Fiat
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website.
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -2946,13 +2946,13 @@ paths:
         - custody
       summary: Create Withdrawal Challenge
       description: |
-        Request a withdrawal challenge for signing, this can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Request a withdrawal challenge for signing which can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         > **Bullish requires you to whitelist a withdrawal destination address before submitting a withdrawal request. You may view, approve, and manage your list of destination addresses in Account Settings on the Bullish website. If you attempt a withdrawal without first whitelisting an address in Account Settings, then the withdrawal attempt will fail.**
         
-        For a full example of using the withdrawal endpoints please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/custody_withdrawals.py)
+        For a full example of using the withdrawal endpoints, please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/custody_withdrawals.py)
         
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
         
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -3008,7 +3008,7 @@ paths:
         - custody
       summary: Assertion for Withdrawal Challenge
       description: |
-        Make assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Make an assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-withdrawal-assertion
@@ -3062,7 +3062,7 @@ paths:
 
         For a full example of using the withdrawal endpoint please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/ecdsa/rest/custody_withdrawal.py)
 
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
 
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -3709,11 +3709,11 @@ components:
     CustodyAvailableWithdrawalLimit:
       type: string
       example: "20000.0"
-      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     Custody24HWithdrawalLimit:
       type: string
       example: "1000000.00"
-      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     CustodyCreatedAtDateTime:
       type: string
       example: "2022-09-16T07:56:15.000Z"

--- a/src/trading-api/draft/perps/bullish-trading-api.yml
+++ b/src/trading-api/draft/perps/bullish-trading-api.yml
@@ -1397,7 +1397,7 @@ tags:
     description: |+
       Authenticated APIs for custody,  [Custody Basic Examples](https://github.com/bullish-exchange/api-examples/blob/master/custody_basics.py)
       
-      Custody APIs have a limit of 40 requests per minute combined across all endpoints of type **/wallets/***
+      Custody APIs have a limit of 40 requests per IP, per minute. This is combined across all endpoints of type **/wallets/***
   - name: trades
     description: Authenticated APIs for reading trade data
   - name: accounts
@@ -2670,7 +2670,7 @@ paths:
         - custody
       summary: Get Custody Transaction History
       description: |
-        Get custody transaction history requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get custody transaction history, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         - [supports pagination](#overview--pagination-support)
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
@@ -2705,7 +2705,7 @@ paths:
         - custody
       summary: Get Withdrawal Limits for Symbol
       description: |
-        Get withdrawal limits for symbol [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal limits for symbol, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-limits
@@ -2740,7 +2740,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Crypto
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -2777,7 +2777,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Crypto
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -2814,7 +2814,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Fiat
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -2852,7 +2852,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Fiat
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website.
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -2889,13 +2889,13 @@ paths:
         - custody
       summary: Create Withdrawal Challenge
       description: |
-        Request a withdrawal challenge for signing, this can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Request a withdrawal challenge for signing which can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         > **Bullish requires you to whitelist a withdrawal destination address before submitting a withdrawal request. You may view, approve, and manage your list of destination addresses in Account Settings on the Bullish website. If you attempt a withdrawal without first whitelisting an address in Account Settings, then the withdrawal attempt will fail.**
         
-        For a full example of using the withdrawal endpoints please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/custody_withdrawals.py)
+        For a full example of using the withdrawal endpoints, please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/custody_withdrawals.py)
         
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
         
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -2951,7 +2951,7 @@ paths:
         - custody
       summary: Assertion for Withdrawal Challenge
       description: |
-        Make assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Make an assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-withdrawal-assertion
@@ -2996,7 +2996,7 @@ paths:
 
         For a full example of using the withdrawal endpoints please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/custody_withdrawals.py)
 
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
 
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -3736,11 +3736,11 @@ components:
     CustodyAvailableWithdrawalLimit:
       type: string
       example: "20000.0"
-      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     Custody24HWithdrawalLimit:
       type: string
       example: "1000000.00"
-      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     CustodyCreatedAtDateTime:
       type: string
       example: "2022-09-16T07:56:15.000Z"

--- a/src/trading-api/next/bullish-trading-api.yml
+++ b/src/trading-api/next/bullish-trading-api.yml
@@ -1821,7 +1821,7 @@ tags:
     description: |+
       Authenticated APIs for custody,  [Custody Basic Examples](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_basics.py)
       
-      Custody APIs have a limit of 40 requests per minute combined across all endpoints of type **/wallets/***
+      Custody APIs have a limit of 40 requests per IP, per minute. This is combined across all endpoints of type **/wallets/***
   - name: trades
     description: Authenticated APIs for reading trade data
   - name: accounts
@@ -3790,7 +3790,7 @@ paths:
         - custody
       summary: Get Custody Transaction History
       description: |
-        Get custody transaction history requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get custody transaction history, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         - [supports pagination](#overview--pagination-support)
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
@@ -3825,7 +3825,7 @@ paths:
         - custody
       summary: Get Withdrawal Limits for Symbol
       description: |
-        Get withdrawal limits for symbol [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal limits for symbol, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-limits
@@ -3860,7 +3860,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Crypto
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -3897,7 +3897,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Crypto
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -3934,7 +3934,7 @@ paths:
         - custody
       summary: Get Deposit Instructions for Fiat
       description: |
-        Get deposit instructions requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get deposit instructions, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-deposit-instructions
@@ -3972,7 +3972,7 @@ paths:
         - custody
       summary: Get Withdrawal Instructions for Fiat
       description: |
-        Get withdrawal instructions added by the user. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website. Requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Get withdrawal instructions added by the user, requires [bearer token](#overview--add-authenticated-request-header) in authorization header. Please note that before withdrawal destinations can be used for withdrawing to, they must be whitelisted on the Bullish website.
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-get-withdrawal-instructions
@@ -4009,13 +4009,13 @@ paths:
         - custody
       summary: Create Withdrawal Challenge
       description: |
-        Request a withdrawal challenge for signing, this can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Request a withdrawal challenge for signing which can later be used to trigger a withdrawal, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         > **Bullish requires you to whitelist a withdrawal destination address before submitting a withdrawal request. You may view, approve, and manage your list of destination addresses in Account Settings on the Bullish website. If you attempt a withdrawal without first whitelisting an address in Account Settings, then the withdrawal attempt will fail.**
         
-        For a full example of using the withdrawal endpoints please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_withdrawals.py)
+        For a full example of using the withdrawal endpoints, please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/bullish/rest/custody_withdrawals.py)
         
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
         
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -4071,7 +4071,7 @@ paths:
         - custody
       summary: Assertion for Withdrawal Challenge
       description: |
-        Make assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
+        Make an assertion (send signature and effect a withdrawal) for a withdrawal challenge created with the [withdrawal-challenge](#post-/wallets/withdrawal-challenge) endpoint, requires [bearer token](#overview--add-authenticated-request-header) in authorization header
         
         **Ratelimited:** `True` - see [custody limits](#tag--custody)
       operationId: custody-withdrawal-assertion
@@ -4125,7 +4125,7 @@ paths:
 
         For a full example of using the withdrawal endpoint please see the [Custody Withdrawal Example](https://github.com/bullish-exchange/api-examples/blob/master/ecdsa/rest/custody_withdrawal.py)
 
-        The currently supported precisions for withdrawal quantities are as follows, and as with fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei) :
+        The currently supported precisions for withdrawal quantities are as follows. Please note that fees are always specified in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei) :
 
         | Symbol | Precision |
         | ---------- |---------------- |
@@ -4997,11 +4997,11 @@ components:
     CustodyAvailableWithdrawalLimit:
       type: string
       example: "20000.0"
-      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: remaining limit on amount of coin or token that could be withdrawn now, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     Custody24HWithdrawalLimit:
       type: string
       example: "1000000.00"
-      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satohshi, ETH not Wei)
+      description: limit on amount of coin or token that can be withdrawn over a 24 hour period, in units of the symbol itself, not in smaller denominations (e.g. BTC not Satoshi, ETH not Wei)
     CustodyCreatedAtDateTime:
       type: string
       example: "2022-09-16T07:56:15.000Z"


### PR DESCRIPTION
Adding clarification that custody API rate limits are per IP to remove ambiguity.